### PR TITLE
feat: support visual mode selection for undoing hunks

### DIFF
--- a/lua/vcsigns/actions.lua
+++ b/lua/vcsigns/actions.lua
@@ -206,8 +206,7 @@ end
 ---@param range integer[]|nil The range of lines to undo hunks in.
 function M.hunk_undo(bufnr, range)
   if not range then
-    local lnum = vim.fn.line "."
-    range = { lnum, lnum }
+    range = vim.fn.sort { vim.fn.line ".", vim.fn.line "v" }
   end
   local hunks_in_range = _hunks_in_range(bufnr, range)
 


### PR DESCRIPTION
Hello!

This supports visual selections with the `v` position, which returns the opposite line of the cursor position when in visual mode or the current line when not in visual mode.

Thanks!