### PR TITLE
fix: range sorting

### DIFF
--- a/lua/vcsigns/actions.lua
+++ b/lua/vcsigns/actions.lua
@@ -206,8 +206,9 @@ end
 ---@param range integer[]|nil The range of lines to undo hunks in.
 function M.hunk_undo(bufnr, range)
   if not range then
-    range = vim.fn.sort { vim.fn.line ".", vim.fn.line "v" }
+    range = { vim.fn.line ".", vim.fn.line "v" }
   end
+  table.sort(range)
   local hunks_in_range = _hunks_in_range(bufnr, range)
 
   if #hunks_in_range == 0 then


### PR DESCRIPTION
Hello!


It turns out that by default `vim.fn.sort` uses string comparisons, and returns the wrong order for certain ranges (e.g., { 24, 6 } does not sort to { 6, 24 }). However, `table.sort()` uses the native lua operator `<` when no comparision function is needed which works for this case.

Note, I decided to move the sort call outside of the inner if, just to ensure that any range passed to the function is sorted properly

Thanks!