### PR TITLE
fix: change_delete sign logic

### DIFF
--- a/lua/vcsigns/init.lua
+++ b/lua/vcsigns/init.lua
@@ -75,7 +75,7 @@ local default_config = {
   -- Initial target commit to show.
   -- 0 means the current commit, 1 is one commit before that, etc.
   target_commit = 0,
-  -- Shot the number of deleted lines in the sign column.
+  -- Show the number of deleted lines in the sign column.
   show_delete_count = true,
   -- Highlight the number in the sign column.
   highlight_number = false,
@@ -98,7 +98,7 @@ local default_config = {
       hl = "SignDeleteFirstLine",
     },
     change_delete = {
-      text = "▏▔",
+      text = "~",
       hl = "SignChangeDelete",
     },
   },

--- a/lua/vcsigns/sign.lua
+++ b/lua/vcsigns/sign.lua
@@ -104,17 +104,7 @@ function M.add_signs(bufnr, hunks)
         local diff = hunk.minus_count - hunk.plus_count
         modified = modified + hunk.plus_count
         deleted = deleted + diff
-
-        local prev_line_available = hunk.plus_start > 1
-          and not sign_lines[hunk.plus_start - 1]
-
-        if prev_line_available then
-          local sign = _delete_with_count(diff)
-          _add_sign(hunk.plus_start, sign)
-        else
-          _add_sign(hunk.plus_start, M.signs.change_delete)
-        end
-
+        _add_sign(hunk.plus_start, M.signs.change_delete)
         _add_sign_range(
           hunk.plus_start + 1,
           hunk.plus_count - 1,


### PR DESCRIPTION
This is one possible solution for #10

When there's a changed line with deleted line(s) before or after it, it was only showing the deleted sign (because the previous line was available).

This also simplifies the logic to always show the change_delete sign regardless whether the deleted line is before or after the changed line. Otherwise, it would be kind of confusing to see `▏▔` for a changed line with deleted lines after it (would need to show `▏▁` instead which would necessitate more complex logic).

Closes #10 

Thanks!