### PR TITLE
Big sign handling rewrite + matchline option

### DIFF
--- a/doc/vcsigns.txt
+++ b/doc/vcsigns.txt
@@ -50,8 +50,6 @@ This plugin uses a handful of highlight groups.
   Sign color for added lines.
 - `SignDelete`  (default: `DiffDelete`)
   Sign color for deleted lines.
-- `SignDeleteFirstLine`  (default: `DiffDelete`)
-  Sign color for deleted lines at the start of a file.
 - `SignChange`  (default: `DiffChange`)
   Sign color for changed lines.
 - `SignChangeDelete`  (default: `SignChange`)

--- a/lua/vcsigns/init.lua
+++ b/lua/vcsigns/init.lua
@@ -112,9 +112,12 @@ local default_config = {
   -- |   13 | Context       2
   -- |   14 | Context       2
   fold_context_sizes = { 1 },
-  -- Diff algorithm to use.
+  -- Diff options to use.
   -- See `:help vim.diff()` for available algorithms.
-  diff_algorithm = "histogram",
+  diff_opts = {
+    algorithm = "histogram",
+    linematch = true,
+  },
   -- Whether to try respecting .gitignore files.
   -- This relies on the `git` command being available.
   -- Works for git repos and git backed jj repos.
@@ -131,7 +134,7 @@ function M.setup(user_config)
   local config = vim.tbl_deep_extend("force", default_config, user_config or {})
   vim.g.vcsigns_show_delete_count = config.show_delete_count
   vim.g.vcsigns_fold_context_sizes = config.fold_context_sizes
-  vim.g.vcsigns_diff_algorithm = config.diff_algorithm
+  vim.g.vcsigns_diff_opts = config.diff_opts
   vim.g.vcsigns_highlight_number = config.highlight_number
   vim.g.vcsigns_target_commit = config.target_commit
   vim.g.vcsigns_respect_gitignore = config.respect_gitignore

--- a/lua/vcsigns/init.lua
+++ b/lua/vcsigns/init.lua
@@ -81,25 +81,18 @@ local default_config = {
   highlight_number = false,
   -- Signs to use for different types of changes.
   signs = {
-    add = {
-      text = "▏",
-      hl = "SignAdd",
+    text = {
+      add = "▏",
+      change = "▏",
+      delete_below = "▁",
+      delete_above = "▔",
+      change_delete = nil, -- Use combined sign.
     },
-    change = {
-      text = "▏",
-      hl = "SignChange",
-    },
-    delete = {
-      text = "▁",
-      hl = "SignDelete",
-    },
-    delete_first_line = {
-      text = "▔",
-      hl = "SignDeleteFirstLine",
-    },
-    change_delete = {
-      text = "▏▔",
-      hl = "SignChangeDelete",
+    hl = {
+      add = "SignAdd",
+      change = "SignChange",
+      delete = "SignDelete",
+      change_delete = "SignChangeDelete",
     },
   },
   -- Sizes of context to add fold levels for (order doesn't matter).

--- a/lua/vcsigns/init.lua
+++ b/lua/vcsigns/init.lua
@@ -95,6 +95,10 @@ local default_config = {
       change_delete = "SignChangeDelete",
     },
   },
+  -- By default multiple signs on one line are avoided by shifting
+  -- delete_below into a delete_above on the next line.
+  -- This can optionally be skipped.
+  skip_sign_decongestion = false,
   -- Sizes of context to add fold levels for (order doesn't matter).
   -- E.g. { 1, 3 } would mean one fold level with a context of 1 line,
   -- and one fold level with a context of 3 lines:
@@ -136,6 +140,7 @@ function M.setup(user_config)
   vim.g.vcsigns_fold_context_sizes = config.fold_context_sizes
   vim.g.vcsigns_diff_opts = config.diff_opts
   vim.g.vcsigns_highlight_number = config.highlight_number
+  vim.g.vcsigns_skip_sign_decongestion = config.skip_sign_decongestion
   vim.g.vcsigns_target_commit = config.target_commit
   vim.g.vcsigns_respect_gitignore = config.respect_gitignore
   M.sign.signs = config.signs

--- a/lua/vcsigns/sign.lua
+++ b/lua/vcsigns/sign.lua
@@ -1,104 +1,212 @@
 local M = {}
 
+local bit = require "bit"
 local util = require "vcsigns.util"
+
+local band = bit.band
+local bor = bit.bor
+
+local function _popcount(x)
+  -- Count the number of bits set in x.
+  local count = 0
+  while x > 0 do
+    count = count + band(x, 1)
+    x = bit.rshift(x, 1)
+  end
+  return count
+end
 
 -- Will be overridden by user config.
 M.signs = nil
 
-local function _sign_namespace()
-  return vim.api.nvim_create_namespace "vcsigns"
+---@enum SignType
+local SignType = {
+  ADD = 1,
+  CHANGE = 2,
+  DELETE_BELOW = 4,
+  DELETE_ABOVE = 8,
+}
+M.SignType = SignType
+
+---@class SignData
+---@field type SignType
+---@field count integer|nil
+local SignData = {}
+
+---@class VimSign
+---@field text string The sign text.
+---@field hl string The highlight group for the sign.
+local VimSign = {}
+
+--- Convert the
+---@param sign SignData
+local function _to_vim_sign(sign)
+  ---@param count integer
+  ---@param text string
+  local function _delete_text(count, text)
+    if not vim.g.vcsigns_show_delete_count then
+      return text
+    end
+    if count == 1 then
+      -- Keep the sign as is.
+    elseif count < 10 then
+      text = text .. count
+    elseif count < 100 then
+      text = "" .. count
+    else
+      text = ">" .. text
+    end
+    return text
+  end
+
+  local count = _popcount(sign.type)
+  if count == 1 then
+    local text = ""
+    local hl = nil
+    if band(sign.type, SignType.ADD) ~= 0 then
+      text = text .. M.signs.text.add
+      hl = M.signs.hl.add
+    elseif band(sign.type, SignType.CHANGE) ~= 0 then
+      text = text .. M.signs.text.change
+      hl = M.signs.hl.change
+    elseif band(sign.type, SignType.DELETE_BELOW) ~= 0 then
+      text = text .. _delete_text(sign.count, M.signs.text.delete_below)
+      hl = M.signs.hl.delete
+    elseif band(sign.type, SignType.DELETE_ABOVE) ~= 0 then
+      text = text .. _delete_text(sign.count, M.signs.text.delete_above)
+      hl = M.signs.hl.delete
+    end
+    return { text = text, hl = hl }
+  end
+  if count == 2 then
+    -- Change-delete.
+    if M.signs.text.change_delete then
+      -- User provided a change-delete sign.
+      return {
+        text = M.signs.text.change_delete,
+        hl = M.signs.hl.change_delete,
+      }
+    end
+    assert(band(sign.type, SignType.CHANGE) ~= 0)
+    assert(band(sign.type, SignType.ADD) == 0)
+    local text = M.signs.text.change
+    if band(sign.type, SignType.DELETE_BELOW) ~= 0 then
+      text = text .. M.signs.text.delete_below
+    elseif band(sign.type, SignType.DELETE_ABOVE) ~= 0 then
+      text = text .. M.signs.text.delete_above
+    end
+    return { text = text, hl = M.signs.hl.change_delete }
+  end
+  error(string.format("Invalid sign type %d with count %d.", sign.type, count))
 end
 
-function M.add_signs_impl(hunks, add_sign)
+--- Adjust signs to be in range and to avoid overlaps.
+---@param signs table<number, SignData> The signs to adjust.
+---@param line_count integer The number of lines in the buffer.
+---@return table<number, SignData> The adjusted signs.
+local function _adjust_signs(signs, line_count)
+  -- Correct deletion on the 0th line, if it exists.
+  if signs[0] then
+    assert(_popcount(signs[0].type) == 1)
+    assert(signs[0].type == SignType.DELETE_BELOW)
+    local one = signs[1] or { type = 0, count = 0 }
+    one.type = bor(one.type, SignType.DELETE_ABOVE)
+    one.count = one.count + signs[0].count
+    signs[1] = one
+    signs[0] = nil
+  end
+  -- See if congested deletion below can be flipped into a deletion above.
+  for i = 1, line_count - 1 do
+    local sign = signs[i]
+    if
+      sign
+      and _popcount(sign.type) > 1
+      and band(sign.type, SignType.DELETE_BELOW) ~= 0
+    then
+      if not signs[i + 1] then
+        -- No sign below, so we can flip it.
+        signs[i + 1] = {
+          type = SignType.DELETE_ABOVE,
+          count = sign.count,
+        }
+        signs[i].type = bit.bxor(sign.type, SignType.DELETE_BELOW)
+        signs[i].count = 0
+      end
+    end
+  end
+  return signs
+end
+
+--- Compute the signs to show for a list of hunks.
+---@param hunks Hunk[]
+---@return { signs: table<number, SignData>, stats: { added: integer, modified: integer, removed: integer } }
+function M.compute_signs(hunks, line_count)
+  ---@type table<number, SignData>
+  local sign_lines = {}
   local added = 0
   local modified = 0
   local deleted = 0
 
-  local sign_lines = {}
-  local function _add_sign(line, sign)
-    if add_sign(line, sign) then
-      sign_lines[line] = true
+  local function _add_sign(line, sign_type, count)
+    local sign = sign_lines[line] or { type = 0, count = 0 }
+    sign.type = bor(sign.type, sign_type)
+    if count then
+      assert(sign.count == 0, "Sign count should be set only once.")
+      sign.count = count
     end
+    sign_lines[line] = sign
   end
 
-  local function _add_sign_range(start, count, sign)
+  local function _add_sign_range(start, count, sign_type)
     for i = 0, count - 1 do
-      _add_sign(start + i, sign)
+      _add_sign(start + i, sign_type, nil)
     end
-  end
-
-  local function _delete_symbol(delete_count)
-    if not vim.g.vcsigns_show_delete_count then
-      return M.signs.delete
-    end
-    local sign = vim.deepcopy(M.signs.delete)
-    if delete_count == 1 then
-      -- Keep the sign as is.
-    elseif delete_count < 10 then
-      sign.text = delete_count .. sign.text
-    elseif delete_count < 100 then
-      sign.text = delete_count .. ""
-    else
-      sign.text = ">" .. sign.text
-    end
-    return sign
   end
 
   for _, hunk in ipairs(hunks) do
     if hunk.minus_count == 0 and hunk.plus_count > 0 then
       -- Pure add.
       added = added + hunk.plus_count
-      _add_sign_range(hunk.plus_start, hunk.plus_count, M.signs.add)
+      _add_sign_range(hunk.plus_start, hunk.plus_count, SignType.ADD)
     elseif hunk.minus_count > 0 and hunk.plus_count == 0 then
       -- Pure delete.
       deleted = deleted + hunk.minus_count
-      if hunk.plus_start == 0 then
-        -- First line delete.
-        _add_sign(1, M.signs.delete_first_line)
-      else
-        _add_sign(hunk.plus_start, _delete_symbol(hunk.minus_count))
-      end
+      _add_sign(hunk.plus_start, SignType.DELETE_BELOW, hunk.minus_count)
     elseif hunk.minus_count > 0 and hunk.plus_count > 0 then
       if hunk.minus_count == hunk.plus_count then
         -- All lines changed.
         modified = modified + hunk.plus_count
-        _add_sign_range(hunk.plus_start, hunk.plus_count, M.signs.change)
+        _add_sign_range(hunk.plus_start, hunk.plus_count, SignType.CHANGE)
       elseif hunk.minus_count < hunk.plus_count then
         -- Some lines added.
         local diff = hunk.plus_count - hunk.minus_count
         modified = modified + hunk.minus_count
         added = added + diff
-        _add_sign_range(hunk.plus_start, hunk.minus_count, M.signs.change)
-        _add_sign_range(hunk.plus_start + hunk.minus_count, diff, M.signs.add)
+        _add_sign_range(hunk.plus_start, hunk.minus_count, SignType.CHANGE)
+        _add_sign_range(hunk.plus_start + hunk.minus_count, diff, SignType.ADD)
       else
         -- Some lines deleted.
         local diff = hunk.minus_count - hunk.plus_count
         modified = modified + hunk.plus_count
         deleted = deleted + diff
-
-        local prev_line_available = hunk.plus_start > 1
-          and not sign_lines[hunk.plus_start - 1]
-
-        if prev_line_available then
-          _add_sign(hunk.plus_start - 1, _delete_symbol(hunk.minus_count))
-          _add_sign_range(hunk.plus_start, hunk.plus_count, M.signs.change)
-        else
-          _add_sign(hunk.plus_start, M.signs.change_delete)
-          _add_sign_range(
-            hunk.plus_start + 1,
-            hunk.plus_count - 1,
-            M.signs.change
-          )
-        end
+        _add_sign(hunk.plus_start - 1, SignType.DELETE_BELOW, hunk.minus_count)
+        _add_sign_range(hunk.plus_start, hunk.plus_count, SignType.CHANGE)
       end
     end
   end
 
   return {
-    added = added,
-    modified = modified,
-    removed = deleted,
+    signs = _adjust_signs(sign_lines, line_count),
+    stats = {
+      added = added,
+      modified = modified,
+      removed = deleted,
+    },
   }
+end
+
+local function _sign_namespace()
+  return vim.api.nvim_create_namespace "vcsigns"
 end
 
 ---@param bufnr integer
@@ -132,11 +240,16 @@ function M.add_signs(bufnr, hunks)
   end
 
   vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
-  local stats = M.add_signs_impl(hunks, _add_sign)
-  if stats then
+  local result = M.compute_signs(hunks, line_count)
+  if result then
     -- Record stats for use in statuslines and similar.
     -- The table format is compatible with the "diff" section of lualine.
-    vim.b[bufnr].vcsigns_stats = stats
+    vim.b[bufnr].vcsigns_stats = result.stats
+    for i = 1, line_count do
+      if result.signs[i] then
+        _add_sign(i, _to_vim_sign(result.signs[i]))
+      end
+    end
   end
 end
 

--- a/lua/vcsigns/sign.lua
+++ b/lua/vcsigns/sign.lua
@@ -116,6 +116,10 @@ local function _adjust_signs(signs, line_count)
     signs[0] = nil
   end
 
+  if vim.g.vcsigns_skip_sign_decongestion then
+    return signs
+  end
+
   local function flip(i)
     signs[i + 1] = {
       type = SignType.DELETE_ABOVE,


### PR DESCRIPTION
The code used (adapted from vim-signify) did not handle matchlines diffs
well, where signs can easily overlap.

This rewrite collects all signs that we would like to place,
apply some rewrites to try to avoid sign overlapping,
and then places combined signs in the buffer.

The breaking config change comes a different setup wrt signs and highlights
which decouples the signs from the highlights.
* There are signs for add, change, delete_below, delete_above.
* There are highlights for add, change, delete, change_delete.

A specific change-delete sign can also be provided to not use combined symbols.