### PR TITLE
fix: highlight fallback linking

### DIFF
--- a/lua/vcsigns/init.lua
+++ b/lua/vcsigns/init.lua
@@ -175,7 +175,11 @@ function M.setup(user_config)
   -- Set default highlights with fallbacks to common groups for signs.
   local function hl_fallbacks(hl_group, fallbacks)
     for _, fallback in ipairs(fallbacks) do
-      vim.api.nvim_set_hl(0, hl_group, { link = fallback, default = true })
+      local hl = vim.api.nvim_get_hl(0, { name = fallback })
+      if next(hl) then
+        vim.api.nvim_set_hl(0, hl_group, { link = fallback, default = true })
+        return
+      end
     end
   end
 


### PR DESCRIPTION
Because of the `default = true` option, the fallback highlight groups were being set linked to the first highlight in the list even if it did not exist and the rest of the list was ignored.

This updates the function to check if the highlight exists before linking.