### PR TITLE
Make sign priority user-configurable

### DIFF
--- a/lua/vcsigns/init.lua
+++ b/lua/vcsigns/init.lua
@@ -88,6 +88,7 @@ local default_config = {
       delete = "SignDelete",
       change_delete = "SignChangeDelete",
     },
+    priority = 5
   },
   -- By default multiple signs on one line are avoided by shifting
   -- delete_below into a delete_above on the next line.

--- a/lua/vcsigns/sign.lua
+++ b/lua/vcsigns/sign.lua
@@ -6,8 +6,6 @@ local util = require "vcsigns.util"
 local band = bit.band
 local bor = bit.bor
 
-local SIGN_PRIORITY = 5
-
 local function _popcount(x)
   -- Count the number of bits set in x.
   local count = 0
@@ -285,7 +283,7 @@ function M.add_signs(bufnr, hunks)
     local config = {
       sign_text = sign.text,
       sign_hl_group = sign.hl,
-      priority = SIGN_PRIORITY,
+      priority = M.signs.priority,
     }
     if vim.g.vcsigns_highlight_number then
       config.number_hl_group = sign.hl


### PR DESCRIPTION
This is intended for users who want to keep the VCSigns at the leftmost position, to get nice alignment, independent of the presence of other signs.

Closes #19

Not sure if you also want docs for this.

The default priority could also be changed, but maybe it's good to keep it low for people who don't have a wide or auto-expanding signcolumn.